### PR TITLE
Update workflow to restore Maven build artifacts

### DIFF
--- a/.github/workflows/reuse_java_deploy.yml
+++ b/.github/workflows/reuse_java_deploy.yml
@@ -14,12 +14,16 @@ jobs:
           cat <(echo -e "${{ secrets.ORG_GPG_PRIVATE_KEY }}") | gpg --batch --import
           gpg --list-secret-keys --keyid-format LONG
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
-      - name: Download JAR Files
-        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
-        continue-on-error: true #parent pom has no jar
+      
+      - name: Restore Maven build artifacts
+        uses: actions/cache/restore@v5
         with:
-          name: jar-files
-          path: .
+          path: |
+            ~/.m2/repository
+            **/target
+          key: build-${{ runner.os }}-${{ github.sha }}
+          fail-on-cache-miss: true
+
       - name: Set up Java for publishing to Maven Central Snapshot Repository
         uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
         with:


### PR DESCRIPTION
Replaced artifact download step with Maven cache restore for build artifacts.
