### PR TITLE
Fix cache handover between build and deploy job

### DIFF
--- a/.github/workflows/reuse_java_build_test.yml
+++ b/.github/workflows/reuse_java_build_test.yml
@@ -27,9 +27,9 @@ jobs:
       run: |
           docker info
     - name: Build with Maven
-      run: mvn -B install --file pom.xml
-    - name: Cache Maven dependencies and build artifacts
-      uses: actions/cache@v5
+      run: mvn -B --no-transfer-progress install --file pom.xml
+    - name: Save Maven build artifacts to cache
+      uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
       with:
         path: |
           ~/.m2/repository/org/eclipse/daanse

--- a/.github/workflows/reuse_java_deploy.yml
+++ b/.github/workflows/reuse_java_deploy.yml
@@ -14,15 +14,6 @@ jobs:
           cat <(echo -e "${{ secrets.ORG_GPG_PRIVATE_KEY }}") | gpg --batch --import
           gpg --list-secret-keys --keyid-format LONG
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
-      
-      - name: Restore Maven build artifacts
-        uses: actions/cache/restore@v5
-        with:
-          path: |
-            ~/.m2/repository
-            **/target
-          key: build-${{ runner.os }}-${{ github.sha }}
-          fail-on-cache-miss: true
 
       - name: Set up Java for publishing to Maven Central Snapshot Repository
         uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
@@ -34,8 +25,18 @@ jobs:
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
           gpg-passphrase: PASSPHRASE
+
+      - name: Restore Maven build artifacts
+        uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+        with:
+          path: |
+            ~/.m2/repository/org/eclipse/daanse
+            **/target
+          key: build-${{ runner.os }}-${{ github.sha }}
+          fail-on-cache-miss: true
+
       - name: deploy
-        run: mvn -Pdeploy --no-transfer-progress --batch-mode deploy
+        run: mvn -Pdeploy --no-transfer-progress --batch-mode -DskipTests deploy
         env:
           MAVEN_USERNAME: ${{ secrets.CENTRAL_SONATYPE_TOKEN_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.CENTRAL_SONATYPE_TOKEN_PASSWORD }}


### PR DESCRIPTION
The restore path list must match the save path list exactly, because actions/cache derives the cache version from the path list. Restore now uses ~/.m2/repository/org/eclipse/daanse like the save side, runs after setup-java so the pom-keyed dependency cache cannot overwrite the fresh artifacts, and deploy skips tests already run in the build job. The save step uses actions/cache/save explicitly instead of the main cache action.
